### PR TITLE
Update time_to_utc.py

### DIFF
--- a/time_to_utc.py
+++ b/time_to_utc.py
@@ -1,6 +1,9 @@
 from datetime import datetime
 
 def convert_timestamp_to_utc(timestamp: str) -> float | int:
-    date = datetime.strptime(timestamp, '%Y-%m-%dT%H:%M:%S.%fZ')
+    try:
+        date = datetime.strptime(timestamp, '%Y-%m-%dT%H:%M:%S.%fZ')
+    except ValueError:
+        date = datetime.strptime(timestamp, '%Y-%m-%dT%H:%M:%SZ')
 
     return date.timestamp()


### PR DESCRIPTION
Handle cases where milliseconds aren't included in the timestamp string passed to `convert_timestamp_to_utc()`

fixes https://github.com/dieperdev/roblox-message-archiver/issues/1